### PR TITLE
Replace backticks with single quotes: somehow backticks are interprete…

### DIFF
--- a/crud-example/justfile
+++ b/crud-example/justfile
@@ -29,5 +29,5 @@ build-native:
 
 # Run the native executable (make sure you build it first using `mvn package -Dnative` and started the database)
 run-native:
-    echo "Run `just stop-database` to stop the database once you are done"
+    echo "Run 'just stop-database' to stop the database once you are done"
     ./target/crud-example-1.0.0-SNAPSHOT-runner


### PR DESCRIPTION
…d as commands